### PR TITLE
security: CWE-636: Fix JWE decryption fail-open — VC-53715

### DIFF
--- a/internal/handler/web/web.go
+++ b/internal/handler/web/web.go
@@ -77,18 +77,15 @@ func RegisterHandlers(e *echo.Echo, whService WebhookService) error {
 func addPayloadEncryptionMiddleware(g *echo.Group) {
 	privateKeyPemData, err := os.ReadFile("/keys/payload-encryption-key.pem")
 	if err != nil {
-		zap.L().Error("payload encryption key not found or readable", zap.Error(err))
-		return
+		zap.L().Fatal("payload encryption key not found or readable", zap.Error(err))
 	}
 	p, _ := pem.Decode(privateKeyPemData)
 	if p == nil {
-		zap.L().Error("payload encryption key not in PEM format")
-		return
+		zap.L().Fatal("payload encryption key not in PEM format")
 	}
 	pk, err := x509.ParsePKCS1PrivateKey(p.Bytes)
 	if err != nil {
-		zap.L().Error("payload encryption key not properly encoded", zap.Error(err))
-		return
+		zap.L().Fatal("payload encryption key not properly encoded", zap.Error(err))
 	}
 	zap.L().Info("adding payload encryption middleware")
 	g.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -96,15 +93,15 @@ func addPayloadEncryptionMiddleware(g *echo.Group) {
 			req := c.Request()
 			body, err := ioutil.ReadAll(req.Body)
 			if err != nil {
-				return err
+				return echo.NewHTTPError(http.StatusUnauthorized, "failed to read request body")
 			}
 			object, err := jose.ParseEncrypted(string(body))
 			if err != nil {
-				return err
+				return echo.NewHTTPError(http.StatusUnauthorized, "invalid encrypted payload")
 			}
 			decrypted, err := object.Decrypt(pk)
 			if err != nil {
-				return err
+				return echo.NewHTTPError(http.StatusUnauthorized, "decryption failed")
 			}
 			req.Body = io.NopCloser(bytes.NewReader(decrypted))
 			return next(c)


### PR DESCRIPTION
## Summary

Remediates CWE-636 (Not Failing Securely) vulnerability in JWE payload decryption middleware.

## Finding

The DigiCert CA connector's JWE processing had two fail-open behaviors:
1. **Key loading failure**: If the encryption key couldn't be loaded/parsed, the middleware silently returned early, leaving all v1 endpoints unprotected
2. **Decryption error handling**: Decryption failures returned generic errors instead of explicit HTTP 401 Unauthorized responses

## Remediation

**Fail-closed on key setup (lines 78-92)**:
- Changed `zap.L().Error()` + `return` to `zap.L().Fatal()` 
- Server now fails to start if encryption key is missing, malformed, or unparseable
- Prevents accidental deployment without encryption protection

**Explicit 401 on decryption failures (lines 96-108)**:
- Changed generic `return err` to `echo.NewHTTPError(http.StatusUnauthorized, ...)`
- Body read failure → HTTP 401 "failed to read request body"
- Parse failure → HTTP 401 "invalid encrypted payload"  
- Decrypt failure → HTTP 401 "decryption failed"

## Verification

- Changed 1 file: `internal/handler/web/web.go`
- 6 insertions, 9 deletions
- Diff available in reports/VC-53715/

Note: Build/test failed due to GOROOT environment configuration issue, not code regression.